### PR TITLE
Public/cart item

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -1,5 +1,7 @@
 class Public::CartItemsController < ApplicationController
 
+  before_action :authenticate_customer!
+
   def index
     @cart_items = CartItem.where(customer_id: current_customer.id)
     @total = 0
@@ -14,9 +16,11 @@ class Public::CartItemsController < ApplicationController
       # cart_itemの情報をアップデート
       cart_item.update(quantity: cart_item.quantity)
       # cart_item.update_cart_item(quantity: params[:cart_item][:quantity])
+      flash[:success] = "カート内商品の個数が変更されました"
       redirect_to cart_items_path
     else
       @cart_item.save
+      flash[:success] = "商品がカートに入りました"
       redirect_to cart_items_path
     end
   end
@@ -24,6 +28,7 @@ class Public::CartItemsController < ApplicationController
   def update
     @cart_item = CartItem.find(params[:id])
     @cart_item.update(cart_item_params)
+    flash[:success] = "カート内商品の個数が変更されました"
     redirect_to cart_items_path
   end
 
@@ -45,6 +50,5 @@ class Public::CartItemsController < ApplicationController
   def cart_item_params
     params.require(:cart_item).permit(:item_id, :quantity)
   end
-
 
 end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -9,8 +9,14 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find(params[:id])
-    @order_details = @order.order_details.all
+    @order = Order.find_by(id: params[:id])
+    if @order.nil?
+      flash[:danger] = "リロードしたため元の画面に遷移しました"
+      redirect_to request.referer
+    else
+      @order = Order.find_by(params[:id])
+      @order_details = @order.order_details.all
+    end
   end
 
   def create
@@ -50,11 +56,28 @@ class Public::OrdersController < ApplicationController
 
     #　新規住所入力の場合
     elsif params[:order][:address_option] == "2"
-      @order.postcode = params[:order][:postcode]
-      @order.address = params[:order][:address]
-      @order.name = params[:order][:name]
-    else
-      render "new"
+      if params[:order][:postcode] == "" && params[:order][:address] == "" && params[:order][:name] == ""
+              flash[:danger] = "新しいお届け先が全て入力されていません"
+              redirect_to request.referer
+
+      elsif params[:order][:postcode] == ""
+            flash[:danger] = "郵便番号が入力されていません"
+            redirect_to request.referer
+
+      elsif params[:order][:address] == ""
+            flash[:danger] = "住所が入力されていません"
+            redirect_to request.referer
+
+      elsif params[:order][:name] == ""
+            flash[:danger] = "宛名が入力されていません"
+            redirect_to request.referer
+
+      else
+        @order.postcode = params[:order][:postcode]
+        @order.address = params[:order][:address]
+        @order.name = params[:order][:name]
+      end
+
     end
 
     @cart_items = current_customer.cart_items.all

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -9,14 +9,8 @@ class Public::OrdersController < ApplicationController
   end
 
   def show
-    @order = Order.find_by(id: params[:id])
-    if @order.nil?
-      flash[:danger] = "リロードしたため元の画面に遷移しました"
-      redirect_to request.referer
-    else
-      @order = Order.find_by(params[:id])
-      @order_details = @order.order_details.all
-    end
+    @order = Order.find(params[:id])
+    @order_details = @order.order_details.all
   end
 
   def create
@@ -56,28 +50,11 @@ class Public::OrdersController < ApplicationController
 
     #　新規住所入力の場合
     elsif params[:order][:address_option] == "2"
-      if params[:order][:postcode] == "" && params[:order][:address] == "" && params[:order][:name] == ""
-              flash[:danger] = "新しいお届け先が全て入力されていません"
-              redirect_to request.referer
-              
-      elsif params[:order][:postcode] == ""
-            flash[:danger] = "郵便番号が入力されていません"
-            redirect_to request.referer
-            
-      elsif params[:order][:address] == ""
-            flash[:danger] = "住所が入力されていません"
-            redirect_to request.referer
-            
-      elsif params[:order][:name] == ""
-            flash[:danger] = "宛名が入力されていません"
-            redirect_to request.referer
-            
-      else
-        @order.postcode = params[:order][:postcode]
-        @order.address = params[:order][:address]
-        @order.name = params[:order][:name]
-      end
-      
+      @order.postcode = params[:order][:postcode]
+      @order.address = params[:order][:address]
+      @order.name = params[:order][:name]
+    else
+      render "new"
     end
 
     @cart_items = current_customer.cart_items.all

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -8,6 +8,8 @@ class CartItem < ApplicationRecord
   #   update(quantity: self.quantity)
   # end
 
+  validates :quantity, presence: true
+  validates :item_id, presence: true
   # 小計を求めるメソッド
   def subtotal
     item.with_tax_price * quantity

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -61,9 +61,9 @@
       </tbody>
     </table>
 
-  <div class="row justify-content-end">
-    <div>合計金額</div>
-    <span><%= @total.to_s(:delimited) %></span>
+  <div class="row justify-content-end font-weight-bold lead">
+    <div class="mr-3">合計金額</div>
+    <span><%= @total.to_s(:delimited) %> 円</span>
   </div>
 
 

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -1,14 +1,25 @@
+<!--フラッシュメッセージの部分テンプレート-->
+<%= render 'layouts/flash_message' %>
+
 <div class="container">
+
   <div class="row align-items-center">
-    <h3 class="col">ショッピングカート</h3>
+    <h3 class="col font-weight-bold">ショッピングカート</h3>
+  </div>
+
+<% if @cart_items.present? %>
 
     <!--カートを空にするボタン-->
-    <div class="col text-right"><%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, class: "btn btn-danger" %></div>
+  <div class="row align-items-end mb-2">
+    <div class="col text-right">
+      <%= link_to "カートを空にする", destroy_all_cart_items_path, method: :delete, data: { confirm: "カート内商品を全て削除しますか？" }, class: "btn btn-sm btn-danger" %>
+    </div>
   </div>
 
     <table class="table">
+
       <thead>
-        <tr>
+        <tr class="align-items-center">
           <th></th>
           <th>商品名</th>
           <th>単価(税込)</th>
@@ -17,6 +28,7 @@
           <th></th>
         </tr>
       </thead>
+
       <tbody>
 
       <% @cart_items.each do |cart_item| %>
@@ -42,7 +54,7 @@
           <td class="form-inline">
             <%= f.select :quantity, [*1..10], {}, required: true, class: "form-control mr-3" %>
             <%= f.hidden_field :item_id, value: cart_item.item_id %>
-            <%= f.submit "変更", method: :patch, class: "btn btn-success" %>
+            <%= f.submit "変更", method: :patch, class: "btn btn-sm btn-success" %>
           </td>
         <% end %>
 
@@ -51,7 +63,7 @@
 
           <!--cart_itemごとの削除ボタン-->
           <td>
-            <%= link_to "削除する", cart_item_path(cart_item), method: :delete, class: "btn btn-danger" %>
+            <%= link_to "削除する", cart_item_path(cart_item), method: :delete, data: { confirm: "#{cart_item.item.name}をカート内から削除しますか？" }, class: "btn btn-sm btn-danger" %>
           </td>
           <!--それぞれに合計金額を出すための処理-->
           <% @total += cart_item.subtotal %>
@@ -62,14 +74,23 @@
     </table>
 
   <div class="row justify-content-end font-weight-bold lead">
-    <div class="mr-3">合計金額</div>
-    <span><%= @total.to_s(:delimited) %> 円</span>
+    <div class="col-2">合計金額</div>
+    <span class="col-2"><%= @total.to_s(:delimited) %> 円</span>
+    <div class="col-3 text-right">
+      <div>
+        <%= link_to "情報入力に進む", new_order_path, class: "btn btn-md btn-success" %>
+      </div>
+    </div>
   </div>
 
+<% else %>
+<div class="row mt-5">
+  <h4 class="col-5 mr-2">カート内は空です</h4>
+</div>
+<% end %>
 
-  <div class="row text-center">
-    <div class="col-4"><%= link_to "買い物を続ける", root_path, class: "btn btn-primary" %></div>
-    <div class="col-4"><%= link_to "情報入力に進む", new_order_path, class: "btn btn-success" %></div>
+  <div class="row mt-5">
+    <div class="col-6"><%= link_to "買い物を続ける", root_path, class: "btn btn-md btn-primary" %></div>
   </div>
 
 </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,13 +1,13 @@
-<div class="containar">
+<div class="container-fluid">
   <div class="row justify-content-md-center">
 
-    <div class="col-2">
+    <div class="col-2 mx-3">
       <!--ジャンル検索-->
       <%= render "public/genres/lists", genres: @genres %>
 
     </div>
 
-    <div class="col-9">
+    <div class="col-9 mx-3">
 
       <h3 class="d-inline font-weight-bold">商品一覧</h3>
       <span>(全<%= @items.count %>件)</span>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,13 +1,13 @@
-<div class="container">
-  <div class="row">
+<div class="container-fluid">
+  <div class="row justify-content-md-center">
 
-    <div class="col-3">
-
-    <!--ジャンル-->
+    <div class="col-2 mx-3">
+      <!--ジャンル検索-->
+      <%= render "public/genres/lists", genres: @genres %>
 
     </div>
 
-    <div class="col-9">
+    <div class="col-9 mx-3">
 
       <div class="row media">
         <div><%= image_tag @item.image, size: "400x300", class: "mr-3" %></div>


### PR DESCRIPTION
- カート内商品画面の見た目を変え、カート内商品がないときの画面を条件分岐で用意しました。
- 顧客側の商品詳細と商品一覧のcolやcontainerの構造を変更、統一化させました。
部分テンプレートが２　メイン部分が９　になってます。
- before_actionでゲストがカートに入れるを行った際、カスタマーのログイン画面に遷移するようにしました。
- itemモデルにバリデーションを追加しました。
- フラッシュメッセージ三件追加しました。
- ordersコントローラに変更が加わっていますが、空白の行のインデントが消えているだけなので、問題は起こらないと思います。
